### PR TITLE
:wrench: fix missing comma in released windows environment

### DIFF
--- a/windows.pkr.js/windows.js.mustache
+++ b/windows.pkr.js/windows.js.mustache
@@ -75,7 +75,7 @@
                 "./scripts/install-nuget.ps1",
                 "./scripts/install-openssh.ps1",
                 "./scripts/install-git.ps1",
-                "./scripts/install-vcredist.ps1"
+                "./scripts/install-vcredist.ps1",
                 "./scripts/disable-windows-update.ps1",
                 "./scripts/disable-windows-defender.ps1"
             ]


### PR DESCRIPTION
This fixes the http error 500 when trying to build the window image, it seems the released hash for windows released on monday was never built on some cloud vendors, resulting in the incapacity to build on windows with a v0.0.18 unmodified.