### PR TITLE
:wink: c++20 support files

### DIFF
--- a/flags/cxx20.cmake
+++ b/flags/cxx20.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_CXX20_CMAKE)
+  return()
+else()
+  set(POLLY_FLAGS_CXX20_CMAKE 1)
+endif()
+
+include(polly_add_cache_flag)
+include(polly_fatal_error)
+
+string(COMPARE EQUAL "${ANDROID_NDK_VERSION}" "" _not_android)
+
+# TODO: test other platfroms, CMAKE_CXX_FLAGS_INIT should work for all
+if(HUNTER_CMAKE_GENERATOR MATCHES "^Visual Studio.*$")
+  polly_fatal_error("Use flags/vs-cxx20.cmake instead")
+elseif(_not_android)
+  polly_add_cache_flag(CMAKE_CXX_FLAGS "-std=c++20")
+else()
+  polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "-std=c++20")
+endif()
+
+# Set CMAKE_CXX_STANDARD to cache to override project local value if present.
+# FORCE added in case CMAKE_CXX_STANDARD already set in cache
+# (e.g. set before 'project' by user).
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ Standard (toolchain)" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED YES CACHE BOOL "C++ Standard required" FORCE)
+set(CMAKE_CXX_EXTENSIONS NO CACHE BOOL "C++ Standard extensions" FORCE)

--- a/linux-cxx20.cmake
+++ b/linux-cxx20.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_CXX20_CMAKE_)
+  return()
+else()
+  set(POLLY_CLANG_CXX20_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++20 support"
+    "Unix Makefiles"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx20.cmake")

--- a/macos-cxx20.cmake
+++ b/macos-cxx20.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_CXX20_CMAKE_)
+  return()
+else()
+  set(POLLY_CLANG_CXX20_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++20 support"
+    "Unix Makefiles"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx20.cmake")

--- a/windows-cxx20.cmake
+++ b/windows-cxx20.cmake
@@ -1,0 +1,28 @@
+# Copyright (c) 2016-2018, Ruslan Baratov
+# Copyright (c) 2017, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_WINDOWS_CXX20_CMAKE_)
+  return()
+else()
+  set(POLLY_WINDOWS_CXX20_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / c++20 support"
+    "MinGW Makefiles"
+)
+
+add_compile_definitions(
+    WIN32_LEAN_AND_MEAN
+    _WIN32_WINNT=0x0A00 
+    __kernel_entry
+	  BOOST_USE_WINDOWS_H
+)
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -femulated-tls " CACHE STRING "")
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx20.cmake")


### PR DESCRIPTION
These are support file for c++20, they were only tested on macos at the moment.

@Lambourl can you add clang13 for all platforms in the distro and add a cxx20 test for the all-feature-tests project in examples/ on tipi-src ?