### PR TITLE
System install mode for windows images

### DIFF
--- a/vs-16-2019.pkr.js/scripts/install-tipi.ps1
+++ b/vs-16-2019.pkr.js/scripts/install-tipi.ps1
@@ -23,6 +23,11 @@ Try {
     # set the TIPI_HOME_DIR during privisioning
     $env:TIPI_HOME_DIR = $provisioningTimeTarget
     $env:TIPI_DISTRO_MODE = $distro_mode
+    
+    # do a system install because otherwise it's the image-creation user who'll get tipi 
+    # installe in his user profile & PATH... which will be deleted on imaging completion
+    # which would result in the tipi.build customer not having a working installation
+    $env:TIPI_INSTALL_SYSTEM = "True"
 
     # have the target folder created and read/writable for everyone
     md $provisioningTimeTarget

--- a/vs-16-2019.pkr.js/vs-16-2019.js.mustache
+++ b/vs-16-2019.pkr.js/vs-16-2019.js.mustache
@@ -49,8 +49,8 @@
             "shared_image_gallery_timeout": "1h30m",
             "shared_image_gallery_replica_count": 1,
             "azure_tags": {
-                "dept": "Engineering",
-                "task": "Image deployment"
+                "tipi_deployment": "<% tipi_deployment %>",
+                "tipi_userid": "<% tipi_userid %>"
             }
         }
     ],

--- a/windows.pkr.js/scripts/install-tipi.ps1
+++ b/windows.pkr.js/scripts/install-tipi.ps1
@@ -23,6 +23,7 @@ Try {
     # set the TIPI_HOME_DIR during privisioning
     $env:TIPI_HOME_DIR = $provisioningTimeTarget
     $env:TIPI_DISTRO_MODE = $distro_mode
+    $env:TIPI_INSTALL_SYSTEM = "True"
 
     # have the target folder created and read/writable for everyone
     md $provisioningTimeTarget

--- a/windows.pkr.js/windows.js.mustache
+++ b/windows.pkr.js/windows.js.mustache
@@ -49,8 +49,8 @@
             "shared_image_gallery_timeout": "1h30m",
             "shared_image_gallery_replica_count": 1,
             "azure_tags": {
-                "dept": "Engineering",
-                "task": "Image deployment"
+                "tipi_deployment": "<% tipi_deployment %>",
+                "tipi_userid": "<% tipi_userid %>"
             }
         }
     ],


### PR DESCRIPTION
When the changes to the installer (see https://github.com/tipi-build/cli/pull/35) will be merged the image builds must run the tipi installer with `SYSTEM_INSTALL_MODE=True` to ensure that the end-user of the image will have a tipi.exe on his `PATH`

Note: I snuck-in a change related to more useful tagging of the generated images. Both of these changes should be non-breaking and could be deployement to "old-tipi" IMHO
