### PR TITLE
Windows based environment provision tipi on C:/ now

### DIFF
--- a/vs-16-2019.pkr.js/scripts/install-git.ps1
+++ b/vs-16-2019.pkr.js/scripts/install-git.ps1
@@ -45,11 +45,13 @@ Install-Binary  -Url $downloadUrl `
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
-Add-MachinePathItem "C:\Program Files\Git\bin"
+# add git bin dir to machine path
+$context = [EnvironmentVariableTarget]::Machine
+$PATH_orig = [Environment]::GetEnvironmentVariable("Path", $context)
 
-if (((Get-CimInstance -ClassName Win32_OperatingSystem).Caption) -match "2016") {
-    $env:Path += ";$env:ProgramFiles\Git\usr\bin\"
-}
+$PATH_new = "C:\Program Files\Git\bin;" + $PATH_orig    # prepending so the latest install wins the path race
+$PATH_new = $PATH_new -replace ';{2,}',';'              # clean the path of eventual double ;; entries
+[Environment]::SetEnvironmentVariable("Path", $PATH_new, $context)
 
 # Add well-known SSH host keys to ssh_known_hosts
 ssh-keyscan -t rsa github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"

--- a/vs-16-2019.pkr.js/scripts/install-tipi.ps1
+++ b/vs-16-2019.pkr.js/scripts/install-tipi.ps1
@@ -11,49 +11,45 @@ if (!$RunningAsAdmin) {
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Try {
-    # the *temporary* storage is not persisted between provisioning
-    # and runtime, hence we want to copy over to the final location POST-boot
-    $provisioningTimeTarget = "C:\.tipi"
-    $runtimeTimeTarget = "D:\.tipi"
-    $distro_mode = "all"
+  # force distro mode all so we have all the requisite tools preinstalled
+  $env:TIPI_DISTRO_MODE = "all"
+  Write-Output "Installing tipi in distro mode '$env:TIPI_DISTRO_MODE'"
 
-    Write-Output "Installing tipi in: "
-    Write-Output $provisioningTimeTarget
+  # do a system install because otherwise it's the image-creation user who'll get tipi 
+  # installe in his user profile & PATH... which will be deleted on imaging completion
+  # which would result in the tipi.build customer not having a working installation
+  $env:TIPI_INSTALL_SYSTEM = "True"
+  Write-Output "Installing tipi in system install mode: $env:TIPI_INSTALL_SYSTEM"
 
-    # set the TIPI_HOME_DIR during privisioning
-    $env:TIPI_HOME_DIR = $provisioningTimeTarget
-    $env:TIPI_DISTRO_MODE = $distro_mode
-    
-    # do a system install because otherwise it's the image-creation user who'll get tipi 
-    # installe in his user profile & PATH... which will be deleted on imaging completion
-    # which would result in the tipi.build customer not having a working installation
-    $env:TIPI_INSTALL_SYSTEM = "True"
+  # have the target folder created and read/writable for everyone
+  $provisioningTimeTarget = "C:\.tipi"
+  mkdir $provisioningTimeTarget
+  icacls $provisioningTimeTarget /grant Users:F
 
-    # have the target folder created and read/writable for everyone
-    md $provisioningTimeTarget
-    icacls $provisioningTimeTarget /grant Users:F
+  # we need that for a few more days I guess
+  $env:TIPI_HOME_DIR = $provisioningTimeTarget
 
-    # install tipi
-    . { iwr -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 } | iex
+  # install tipi
+  . { Invoke-WebRequest -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 } | Invoke-Expression
 
-    # set the TIPI_HOME_DIR to our runtime target directory and setup file-sync
-    [System.Environment]::SetEnvironmentVariable('TIPI_HOME_DIR', $runtimeTimeTarget, [System.EnvironmentVariableTarget]::Machine)
-
-    # schedule a job to sync stuff between the c: and d: drive after startup
-    $taskTrigger = New-ScheduledTaskTrigger -AtStartup
-    $taskUser = "NT AUTHORITY\SYSTEM"
-    $taskAction = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument "-file c:\Temp\sync-tipi-distro.ps1"
-    $taskPriority = 1 # 0: "realtime" / 1: highest prio ... 9: lowest    
-    $taskSettings = New-ScheduledTaskSettingsSet -Priority $taskPriority
-    Register-ScheduledTask -TaskName "tipi-distro-sync" -Trigger $taskTrigger -User $taskUser -Action $taskAction -Settings $taskSettings -RunLevel Highest -Force
-
-    # clean up the download folder to have less clutter
-    Remove-Item -Recurse -Force "$provisioningTimeTarget\downloads\*"
+  try {
+    # clean up the download folder to have less clutter / smaller images
+    Get-ChildItem "$provisioningTimeTarget\downloads\*" -Recurse -Force `
+    | Sort-Object -Property FullName -Descending `
+    | ForEach-Object {
+      Remove-Item -Path $_.FullName -Force -ErrorAction Stop;
+    }
+  }
+  catch {
+    Write-Host " XXX Failed to clean download folder"
+    Write-Host ($_ | ConvertTo-Json)  -ErrorAction Continue
+  }
 
 } Catch {
-    Write-Error "Failed to install tipicli :'("
-    $host.SetShouldExit(-1)
-    throw
+  Write-Error "Failed to install tipicli :'(" -ErrorAction Continue
+  Write-Error ($_ | ConvertTo-Json) -ErrorAction Continue
+  $host.SetShouldExit(-1)
+  throw
 }
 
 Write-Output "Installed tipicli."

--- a/windows.pkr.js/scripts/install-git.ps1
+++ b/windows.pkr.js/scripts/install-git.ps1
@@ -45,11 +45,13 @@ Install-Binary  -Url $downloadUrl `
 # Disable GCM machine-wide
 [Environment]::SetEnvironmentVariable("GCM_INTERACTIVE", "Never", [System.EnvironmentVariableTarget]::Machine)
 
-Add-MachinePathItem "C:\Program Files\Git\bin"
+# add git bin dir to machine path
+$context = [EnvironmentVariableTarget]::Machine
+$PATH_orig = [Environment]::GetEnvironmentVariable("Path", $context)
 
-if (((Get-CimInstance -ClassName Win32_OperatingSystem).Caption) -match "2016") {
-    $env:Path += ";$env:ProgramFiles\Git\usr\bin\"
-}
+$PATH_new = "C:\Program Files\Git\bin;" + $PATH_orig    # prepending so the latest install wins the path race
+$PATH_new = $PATH_new -replace ';{2,}',';'              # clean the path of eventual double ;; entries
+[Environment]::SetEnvironmentVariable("Path", $PATH_new, $context)
 
 # Add well-known SSH host keys to ssh_known_hosts
 ssh-keyscan -t rsa github.com >> "C:\Program Files\Git\etc\ssh\ssh_known_hosts"

--- a/windows.pkr.js/scripts/install-tipi.ps1
+++ b/windows.pkr.js/scripts/install-tipi.ps1
@@ -11,45 +11,45 @@ if (!$RunningAsAdmin) {
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Try {
-    # the *temporary* storage is not persisted between provisioning
-    # and runtime, hence we want to copy over to the final location POST-boot
-    $provisioningTimeTarget = "C:\.tipi"
-    $runtimeTimeTarget = "D:\.tipi"
-    $distro_mode = "all"
+  # force distro mode all so we have all the requisite tools preinstalled
+  $env:TIPI_DISTRO_MODE = "all"
+  Write-Output "Installing tipi in distro mode '$env:TIPI_DISTRO_MODE'"
 
-    Write-Output "Installing tipi in: "
-    Write-Output $provisioningTimeTarget
+  # do a system install because otherwise it's the image-creation user who'll get tipi 
+  # installe in his user profile & PATH... which will be deleted on imaging completion
+  # which would result in the tipi.build customer not having a working installation
+  $env:TIPI_INSTALL_SYSTEM = "True"
+  Write-Output "Installing tipi in system install mode: $env:TIPI_INSTALL_SYSTEM"
 
-    # set the TIPI_HOME_DIR during privisioning
-    $env:TIPI_HOME_DIR = $provisioningTimeTarget
-    $env:TIPI_DISTRO_MODE = $distro_mode
-    $env:TIPI_INSTALL_SYSTEM = "True"
+  # have the target folder created and read/writable for everyone
+  $provisioningTimeTarget = "C:\.tipi"
+  mkdir $provisioningTimeTarget
+  icacls $provisioningTimeTarget /grant Users:F
 
-    # have the target folder created and read/writable for everyone
-    md $provisioningTimeTarget
-    icacls $provisioningTimeTarget /grant Users:F
+  # we need that for a few more days I guess
+  $env:TIPI_HOME_DIR = $provisioningTimeTarget
 
-    # install tipi
-    . { iwr -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 } | iex
+  # install tipi
+  . { Invoke-WebRequest -useb https://raw.githubusercontent.com/tipi-build/cli/master/install/install_for_windows.ps1 } | Invoke-Expression
 
-    # set the TIPI_HOME_DIR to our runtime target directory and setup file-sync
-    [System.Environment]::SetEnvironmentVariable('TIPI_HOME_DIR', $runtimeTimeTarget, [System.EnvironmentVariableTarget]::Machine)
-
-    # schedule a job to sync stuff between the c: and d: drive after startup
-    $taskTrigger = New-ScheduledTaskTrigger -AtStartup
-    $taskUser = "NT AUTHORITY\SYSTEM"
-    $taskAction = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument "-file c:\Temp\sync-tipi-distro.ps1"
-    $taskPriority = 1 # 0: "realtime" / 1: highest prio ... 9: lowest    
-    $taskSettings = New-ScheduledTaskSettingsSet -Priority $taskPriority
-    Register-ScheduledTask -TaskName "tipi-distro-sync" -Trigger $taskTrigger -User $taskUser -Action $taskAction -Settings $taskSettings -RunLevel Highest -Force
-
-    # clean up the download folder to have less clutter
-    Remove-Item -Recurse -Force "$provisioningTimeTarget\downloads\*"
+  try {
+    # clean up the download folder to have less clutter / smaller images
+    Get-ChildItem "$provisioningTimeTarget\downloads\*" -Recurse -Force `
+    | Sort-Object -Property FullName -Descending `
+    | ForEach-Object {
+      Remove-Item -Path $_.FullName -Force -ErrorAction Stop;
+    }
+  }
+  catch {
+    Write-Host " XXX Failed to clean download folder"
+    Write-Host ($_ | ConvertTo-Json)  -ErrorAction Continue
+  }
 
 } Catch {
-    Write-Error "Failed to install tipicli :'("
-    $host.SetShouldExit(-1)
-    throw
+  Write-Error "Failed to install tipicli :'(" -ErrorAction Continue
+  Write-Error ($_ | ConvertTo-Json) -ErrorAction Continue
+  $host.SetShouldExit(-1)
+  throw
 }
 
 Write-Output "Installed tipicli."


### PR DESCRIPTION
script because we now reside on c: anyways

this means we can skip on synching the TIPI_HOME_DIR to  the temp drive vs what we did previously
+ a small fix in the git installer