### PR TITLE
Fix debug builds in projects that don't respect CMAKE_DEBUG_PREFIX

### DIFF
--- a/linux-wine-msvc.cmake
+++ b/linux-wine-msvc.cmake
@@ -29,6 +29,9 @@ polly_init(
 
 SET(CMAKE_CXX_FLAGS_DEBUG "/Ob0 /Od /RTC1" CACHE STRING "")
 
+# can be troublesome for some builds that do not respect that flag, unexpected on "windows"
+set(CMAKE_DEBUG_POSTFIX "")
+
 # inject "system include/lib" information from tipi's MSVC-wine environments
 set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES $ENV{TIPI_MSVC_WINE__LINUX__INCLUDE})
 link_directories($ENV{TIPI_MSVC_WINE__LINUX__LIB})


### PR DESCRIPTION
Setting that flag to `""` so builds that do not respect the flag don't get confused on `linux-wine-msvc` toolchain

Fixes: 
- https://github.com/tipi-build/specs-integration-engflow/issues/61


Related:
- https://github.com/tipi-build/environments-staging/pull/8