### PR TITLE
:gear: Reference rust enabled docker

### DIFF
--- a/linux.pkr.js
+++ b/linux.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu:{{tipi_cli_version}}",
+      "image": "tipibuild/tipi-ubuntu-staging-1185:latest",
       "commit": true
     }
   ],


### PR DESCRIPTION
For v0.0.53 rust support in remote build