### PR TITLE
:gear: tag official environmments by git revision

### DIFF
--- a/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
+++ b/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-almalinux-95:{{tipi_cli_local_version}}",
+      "image": "tipibuild/tipi-almalinux-95:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }

--- a/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.pkr.js
+++ b/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu-1604:{{tipi_cli_local_version}}",
+      "image": "tipibuild/tipi-ubuntu-1604:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }

--- a/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.pkr.js
+++ b/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu-2404:{{tipi_cli_local_version}}",
+      "image": "tipibuild/tipi-ubuntu-2404:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }

--- a/linux-wine-msvc.pkr.js/linux-wine-msvc.pkr.js
+++ b/linux-wine-msvc.pkr.js/linux-wine-msvc.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu-wine-msvc:{{tipi_cli_local_version}}",
+      "image": "tipibuild/tipi-ubuntu-wine-msvc:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }

--- a/linux.pkr.js/linux.pkr.js
+++ b/linux.pkr.js/linux.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu:{{tipi_cli_local_version}}",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }


### PR DESCRIPTION
With {{cmake_re_source_hash}} the official environments are refered to with a tag matching the commit id of cmake-re, matching the version of cmake-re which is used to build the official environment, impacting the envzip hash with the cmake-re original git revision.

Therefore ensuring rebuilds of environments on new cmake-re releases.

This replaces the use of {{tipi_version_hash}} which referred to the released version of cmake-re.