### PR TITLE
Add new toolchain vs-17-2022 support 

### DIFF
--- a/build_engine_mapping.json
+++ b/build_engine_mapping.json
@@ -1,4 +1,6 @@
 {
   "vs-15-2017-win64-cxx17" : "Visual Studio 15 2017 Win64",
-  "vs-16-2019-win64-cxx17" : "Visual Studio 16 2019"
+  "vs-16-2019-win64-cxx17" : "Visual Studio 16 2019",
+  "vs-17-2022-win64-cxx17" : "Visual Studio 17 2022"
+
 }

--- a/vs-17-2022-win64-cxx17.cmake
+++ b/vs-17-2022-win64-cxx17.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2015-2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_17_2022_WIN64_CXX17_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_17_2022_WIN64_CXX17_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 17 2022 Win64 / C++17"
+    "Visual Studio 17 2022"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/vs-cxx17.cmake")
+
+add_compile_definitions(
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+    _WIN32_WINNT=0x0A00 # We have to set the windows version targeted
+    WINVER=0x0A00 # We have to set the windows version targeted
+    LYRA_CONFIG_OPTIONAL_TYPE=std::optional
+
+)
+
+set (CMAKE_SYSTEM_VERSION "10.0.22621.0" CACHE STRING "Ensure WinSDK is recent enough to compile in C++17" FORCE )


### PR DESCRIPTION
the purpose of this pr is to support a new toolchain within our environment in order to allow tipi to build on windows-2022 machines.