### PR TITLE
🔧 remove post-processors in pkr.js file

### DIFF
--- a/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
+++ b/linux-almalinux-95.pkr.js/linux-almalinux-95.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-almalinux-95:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }

--- a/linux-custom-almalinux-95.pkr.js/linux-custom-almalinux-95.pkr.js
+++ b/linux-custom-almalinux-95.pkr.js/linux-custom-almalinux-95.pkr.js
@@ -6,12 +6,5 @@
       "image": "linux-custom-almalinux-95:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }

--- a/linux-custom.pkr.js/linux-custom.pkr.js
+++ b/linux-custom.pkr.js/linux-custom.pkr.js
@@ -6,13 +6,6 @@
       "image": "linux-custom:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 
 }

--- a/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.pkr.js
+++ b/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-ubuntu-1604:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }

--- a/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.pkr.js
+++ b/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-ubuntu-2404:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }

--- a/linux-wine-msvc.pkr.js/linux-wine-msvc.pkr.js
+++ b/linux-wine-msvc.pkr.js/linux-wine-msvc.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-ubuntu-wine-msvc:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux-wine-msvc",
-      "tag": "latest"
-    }
   ]
 }

--- a/linux.pkr.js/linux.pkr.js
+++ b/linux.pkr.js/linux.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }


### PR DESCRIPTION
Removal of post processors because cmake-re/tipi now generates them on the fly