### PR TITLE
:gear: sync official tipi container images and install scripts

### DIFF
--- a/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
+++ b/linux-almalinux-95.pkr.js/linux-almalinux-95.Dockerfile
@@ -8,7 +8,7 @@ ENV SUDO_GROUP=wheel
 ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
 COPY --from=tipi /tipi-linux-x86_64.zip .
 RUN yum update -y && yum install -y ca-certificates 
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
 
 USER tipi
 WORKDIR /home/tipi

--- a/linux-custom-almalinux-95.pkr.js/linux-custom-almalinux-95.Dockerfile
+++ b/linux-custom-almalinux-95.pkr.js/linux-custom-almalinux-95.Dockerfile
@@ -7,7 +7,7 @@ ENV TIPI_INSTALL_LEGACY_PACKAGES=OFF
 ENV SUDO_GROUP=wheel
 ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
 COPY --from=tipi /tipi-linux-x86_64.zip .
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
 
 USER tipi
 WORKDIR /home/tipi

--- a/linux-custom-amazonlinux-2.pkr.js/linux-custom-amazonlinux-2.Dockerfile
+++ b/linux-custom-amazonlinux-2.pkr.js/linux-custom-amazonlinux-2.Dockerfile
@@ -7,7 +7,7 @@ ENV TIPI_INSTALL_LEGACY_PACKAGES=OFF
 ENV SUDO_GROUP=wheel
 ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
 COPY --from=tipi /tipi-linux-x86_64.zip .
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
 
 USER tipi
 WORKDIR /home/tipi

--- a/linux-custom-amazonlinux-2023.pkr.js/linux-custom-amazonlinux-2023.Dockerfile
+++ b/linux-custom-amazonlinux-2023.pkr.js/linux-custom-amazonlinux-2023.Dockerfile
@@ -7,7 +7,7 @@ ENV TIPI_INSTALL_LEGACY_PACKAGES=OFF
 ENV SUDO_GROUP=wheel
 ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
 COPY --from=tipi /tipi-linux-x86_64.zip .
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/centos.sh -o centos.sh && /bin/bash centos.sh
 
 USER tipi
 WORKDIR /home/tipi

--- a/linux-custom.pkr.js/linux-custom.Dockerfile
+++ b/linux-custom.pkr.js/linux-custom.Dockerfile
@@ -9,7 +9,7 @@ COPY --from=tipi /tipi-linux-x86_64.zip .
 ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
 # Install tipi and cmake-re
 RUN apt update -y && apt install -y curl gettext
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
 USER tipi
 WORKDIR /home/tipi
 EXPOSE 22

--- a/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.Dockerfile
+++ b/linux-ubuntu-1604.pkr.js/linux-ubuntu-1604.Dockerfile
@@ -16,5 +16,5 @@ COPY ./pam-config/pam.d/su /etc/pam.d/
 COPY ./pam-config/pam.d/su-l /etc/pam.d/
 
 RUN apt update -y && apt install -y curl gettext
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
 EXPOSE 22

--- a/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.Dockerfile
+++ b/linux-ubuntu-2404.pkr.js/linux-ubuntu-2404.Dockerfile
@@ -9,7 +9,7 @@ COPY --from=tipi /tipi-linux-x86_64.zip .
 ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
 # Install tipi and cmake-re
 RUN apt update -y && apt install -y curl gettext build-essential
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
 USER tipi
 WORKDIR /home/tipi
 EXPOSE 22

--- a/linux-ubuntu-musl-2404.pkr.js/linux-ubuntu-musl-2404.Dockerfile
+++ b/linux-ubuntu-musl-2404.pkr.js/linux-ubuntu-musl-2404.Dockerfile
@@ -119,7 +119,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gettext \
   && rm -rf /var/lib/apt/lists/*
 # Install script for v0.0.80
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/11469c0ac2612565000444950cf0e8dcdd827657/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
 
 # Configure tipi user
 USER tipi

--- a/linux.pkr.js/linux.Dockerfile
+++ b/linux.pkr.js/linux.Dockerfile
@@ -10,5 +10,5 @@ ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
 # Install tipi and cmake-re
 
 RUN apt update -y && apt install -y curl gettext
-RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/4d3116738b96de360fb5cd7653472b041bca3de1/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/2f7d8734e05c0cb6dd23bbdd27234c75676bac1e/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
 EXPOSE 22


### PR DESCRIPTION
Official container images released alongside cmake-re were not using the latest version of the install script.

Fix tipi-build/specs-cmake-re#425